### PR TITLE
Fixing example of taking screenshot

### DIFF
--- a/wiki/graphics/taking-a-screenshot.md
+++ b/wiki/graphics/taking-a-screenshot.md
@@ -8,16 +8,16 @@ Screenshots are easy in libGDX!
 This will guarantee your screenshots look like just like what the user expects:
 
 ```java
-byte[] pixels = Pixmap.createFromFrameBuffer(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight(), true);
+Pixmap pixmap = Pixmap.createFromFrameBuffer(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
+ByteBuffer pixels = pixmap.getPixels();
 
 // This loop makes sure the whole screenshot is opaque and looks exactly like what the user is seeing
-for (int i = 4; i <= pixels.length; i += 4) {
-    pixels[i - 1] = (byte) 255;
+int size = Gdx.graphics.getBackBufferWidth()*Gdx.graphics.getBackBufferHeight()*4;
+for (int i = 3; i < size; i += 4) {
+	pixels.put(i, (byte) 255);
 }
 
-Pixmap pixmap = new Pixmap(Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight(), Pixmap.Format.RGBA8888);
-BufferUtils.copy(pixels, 0, pixmap.getPixels(), pixels.length);
-PixmapIO.writePNG(Gdx.files.external("mypixmap.png"), pixmap);
+PixmapIO.writePNG(Gdx.files.external("mypixmap.png"), pixmap, Deflater.DEFAULT_COMPRESSION, true);
 pixmap.dispose();
 ```
 


### PR DESCRIPTION
The method `Pixmap.createFromFrameBuffer` have different return type and parameter count than in example.